### PR TITLE
Migrate agent context index schema and isolate rebuild process

### DIFF
--- a/gongkao/agent_indexer.py
+++ b/gongkao/agent_indexer.py
@@ -1,6 +1,9 @@
 import logging
+import multiprocessing
+import signal
 import threading
 
+from .db import connect
 from .agent_retrieval.indexing import (
     coalesce_agent_context_pending,
     finalize_agent_context_index,
@@ -10,51 +13,148 @@ from .agent_retrieval.indexing import (
 )
 
 
+def _format_process_exit(exitcode):
+    if exitcode is None:
+        return "agent index subprocess exited without an exit code"
+    if exitcode < 0:
+        signal_number = -int(exitcode)
+        try:
+            signal_name = signal.Signals(signal_number).name
+        except ValueError:
+            signal_name = ""
+        suffix = f" ({signal_name})" if signal_name else ""
+        return f"agent index subprocess exited with signal {signal_number}{suffix}"
+    return f"agent index subprocess exited with exit code {exitcode}"
+
+
+def _run_agent_index_loop(
+    db_path,
+    stop_event,
+    batch_size,
+    idle_seconds,
+    batch_pause_seconds,
+):
+    while not stop_event.is_set():
+        try:
+            coalesce_agent_context_pending(db_path)
+            if rebuild_agent_context_index_if_needed(db_path):
+                stop_event.wait(batch_pause_seconds)
+                continue
+            processed = process_agent_context_pending_batch(
+                db_path,
+                batch_size=batch_size,
+            )
+            if processed:
+                stop_event.wait(batch_pause_seconds)
+                continue
+            refreshed = refresh_agent_knowledge_if_needed(db_path)
+            finalized = finalize_agent_context_index(db_path)
+            if refreshed or finalized:
+                stop_event.wait(batch_pause_seconds)
+                continue
+        except Exception:
+            logging.exception("Background agent index cycle failed")
+        stop_event.wait(idle_seconds)
+
+
 class AgentIndexWorker:
     def __init__(self, db_path, batch_size=8, idle_seconds=1.0, batch_pause_seconds=0.15):
         self.db_path = str(db_path)
         self.batch_size = max(1, int(batch_size))
         self.idle_seconds = max(0.1, float(idle_seconds))
         self.batch_pause_seconds = max(0.05, float(batch_pause_seconds))
-        self._stop_event = threading.Event()
+        self._mp_context = multiprocessing.get_context("spawn")
+        self._stop_event = self._mp_context.Event()
         self._thread = None
+        self._process = None
 
     def start(self):
         if self._thread and self._thread.is_alive():
             return
+        self._stop_event.clear()
         self._thread = threading.Thread(
-            target=self._run,
-            name="gongkao-agent-indexer",
+            target=self._supervise,
+            name="gongkao-agent-indexer-supervisor",
             daemon=True,
         )
         self._thread.start()
 
     def stop(self, timeout=5):
         self._stop_event.set()
+        process = self._process
+        if process and process.is_alive():
+            process.join(timeout=timeout)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=timeout)
+            if process.is_alive():
+                process.kill()
+                process.join(timeout=timeout)
         thread = self._thread
         if thread and thread.is_alive():
             thread.join(timeout=timeout)
         self._thread = None
+        self._process = None
+
+    def _start_process(self):
+        process = self._mp_context.Process(
+            target=_run_agent_index_loop,
+            args=(
+                self.db_path,
+                self._stop_event,
+                self.batch_size,
+                self.idle_seconds,
+                self.batch_pause_seconds,
+            ),
+            name="gongkao-agent-indexer",
+        )
+        process.daemon = True
+        process.start()
+        return process
+
+    def _record_subprocess_exit(self, exitcode):
+        message = _format_process_exit(exitcode)
+        logging.error(message)
+        try:
+            with connect(self.db_path) as conn:
+                conn.execute(
+                    "INSERT OR IGNORE INTO agent_context_worker_state (id) VALUES (1)"
+                )
+                conn.execute(
+                    """
+                    UPDATE agent_context_worker_state
+                       SET status = 'failed',
+                           current_type = '',
+                           last_error = ?,
+                           updated_at = CURRENT_TIMESTAMP
+                     WHERE id = 1
+                    """,
+                    (message[:600],),
+                )
+        except Exception:
+            logging.exception("Failed to record agent index subprocess exit")
+
+    def _supervise(self):
+        while not self._stop_event.is_set():
+            process = self._start_process()
+            self._process = process
+            while process.is_alive() and not self._stop_event.is_set():
+                process.join(timeout=0.2)
+            if self._stop_event.is_set():
+                break
+            exitcode = process.exitcode
+            self._process = None
+            if exitcode:
+                self._record_subprocess_exit(exitcode)
+            else:
+                logging.warning("Agent index subprocess exited unexpectedly")
+            self._stop_event.wait(self.idle_seconds)
 
     def _run(self):
-        while not self._stop_event.is_set():
-            try:
-                coalesce_agent_context_pending(self.db_path)
-                if rebuild_agent_context_index_if_needed(self.db_path):
-                    self._stop_event.wait(self.batch_pause_seconds)
-                    continue
-                processed = process_agent_context_pending_batch(
-                    self.db_path,
-                    batch_size=self.batch_size,
-                )
-                if processed:
-                    self._stop_event.wait(self.batch_pause_seconds)
-                    continue
-                refreshed = refresh_agent_knowledge_if_needed(self.db_path)
-                finalized = finalize_agent_context_index(self.db_path)
-                if refreshed or finalized:
-                    self._stop_event.wait(self.batch_pause_seconds)
-                    continue
-            except Exception:
-                logging.exception("Background agent index cycle failed")
-            self._stop_event.wait(self.idle_seconds)
+        _run_agent_index_loop(
+            self.db_path,
+            self._stop_event,
+            self.batch_size,
+            self.idle_seconds,
+            self.batch_pause_seconds,
+        )

--- a/gongkao/db.py
+++ b/gongkao/db.py
@@ -639,6 +639,7 @@ SCHEMA_V4_ADDITIVE_TABLES = frozenset(
     {
         "agent_ai_settings",
         "agent_context_vectors",
+        "agent_context_dense_vectors",
         "agent_context_fts",
         "agent_context_worker_state",
     }
@@ -692,6 +693,60 @@ def _table_names(conn):
             "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
         )
     }
+
+
+def _column_names(conn, table):
+    return {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _ensure_agent_context_schema(conn):
+    changed = False
+    tables = _table_names(conn)
+    if "agent_context_chunks" in tables:
+        chunk_columns = _column_names(conn, "agent_context_chunks")
+        if "content_hash" not in chunk_columns:
+            conn.execute(
+                "ALTER TABLE agent_context_chunks "
+                "ADD COLUMN content_hash TEXT NOT NULL DEFAULT ''"
+            )
+            changed = True
+    if "agent_context_vectors" in tables:
+        vector_columns = _column_names(conn, "agent_context_vectors")
+        if "content_hash" not in vector_columns:
+            conn.execute(
+                "ALTER TABLE agent_context_vectors "
+                "ADD COLUMN content_hash TEXT NOT NULL DEFAULT ''"
+            )
+            changed = True
+    if "agent_context_dense_vectors" not in tables:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS agent_context_dense_vectors (
+                chunk_id INTEGER NOT NULL REFERENCES agent_context_chunks(id) ON DELETE CASCADE,
+                embedding_model TEXT NOT NULL,
+                dimensions INTEGER NOT NULL,
+                vector_json TEXT NOT NULL,
+                content_hash TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (chunk_id, embedding_model)
+            )
+            """
+        )
+        changed = True
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_agent_context_dense_model
+        ON agent_context_dense_vectors(embedding_model, dimensions, chunk_id)
+        """
+    )
+    if changed and "agent_context_index_state" in _table_names(conn):
+        conn.execute(
+            "INSERT OR IGNORE INTO agent_context_index_state (id, dirty, full_rebuild) "
+            "VALUES (1, 1, 1)"
+        )
+        conn.execute(
+            "UPDATE agent_context_index_state SET dirty = 1, full_rebuild = 1 WHERE id = 1"
+        )
 
 
 def _ensure_index_queue_triggers(conn):
@@ -805,6 +860,7 @@ def init_db(db_path):
                 }
                 if "answer_format_json" not in attempt_columns:
                     raise RuntimeError("current database schema is incomplete; missing attempts.answer_format_json")
+                _ensure_agent_context_schema(conn)
                 _ensure_index_worker_schema(conn)
                 try:
                     conn.execute("PRAGMA journal_mode = WAL")

--- a/tests/test_agent_system.py
+++ b/tests/test_agent_system.py
@@ -659,6 +659,32 @@ class AgentSystemTest(unittest.TestCase):
             worker._run()
         worker._stop_event.wait.assert_called_once_with(0.17)
 
+    def test_background_indexer_records_subprocess_signal_exit(self):
+        class ExitedProcess:
+            exitcode = -11
+
+            def is_alive(self):
+                return False
+
+            def join(self, timeout=None):
+                return None
+
+        worker = AgentIndexWorker(self.db_file, idle_seconds=0.1)
+        worker._start_process = MagicMock(return_value=ExitedProcess())
+        worker._stop_event = MagicMock()
+        worker._stop_event.is_set.side_effect = [False, False, True]
+
+        with patch("gongkao.agent_indexer.logging.error"):
+            worker._supervise()
+
+        with connect(self.db_file) as conn:
+            state = conn.execute(
+                "SELECT status, last_error FROM agent_context_worker_state WHERE id = 1"
+            ).fetchone()
+        self.assertEqual(state["status"], "failed")
+        self.assertIn("signal 11", state["last_error"])
+        worker._stop_event.wait.assert_called_once_with(0.1)
+
     def test_attempt_update_refreshes_only_pending_chunks(self):
         with connect(self.db_file) as conn:
             rebuild_agent_context_index(conn)

--- a/tests/test_release_runtime.py
+++ b/tests/test_release_runtime.py
@@ -13,7 +13,7 @@ from urllib.request import Request, urlopen
 
 import launcher as desktop_launcher
 from gongkao.ai_config import load_effective_agent_settings
-from gongkao.db import CURRENT_SCHEMA_VERSION, connect, prepare_user_database
+from gongkao.db import CURRENT_SCHEMA_VERSION, connect, init_db, prepare_user_database
 from gongkao.grading import build_grading_package
 from gongkao.organizations import canonicalize_organization
 from gongkao.services.personal_records import (
@@ -231,6 +231,53 @@ class ReleaseRuntimeTest(unittest.TestCase):
         audit_database(SEED)
         with connect(SEED) as conn:
             self.assertEqual(conn.execute("PRAGMA user_version").fetchone()[0], CURRENT_SCHEMA_VERSION)
+
+    def test_agent_context_content_hash_columns_are_added_to_old_database(self):
+        with tempfile.TemporaryDirectory() as directory:
+            user_db = Path(directory) / "gongkao.sqlite3"
+            init_db(user_db)
+            with connect(user_db) as conn:
+                conn.execute(
+                    "UPDATE agent_context_index_state SET dirty = 0, full_rebuild = 0 WHERE id = 1"
+                )
+                conn.execute("ALTER TABLE agent_context_chunks DROP COLUMN content_hash")
+                conn.execute("ALTER TABLE agent_context_vectors DROP COLUMN content_hash")
+                conn.execute("DROP TABLE agent_context_dense_vectors")
+                conn.execute("PRAGMA user_version = 5")
+
+            init_db(user_db)
+
+            with connect(user_db) as conn:
+                chunk_columns = {
+                    row["name"]
+                    for row in conn.execute("PRAGMA table_info(agent_context_chunks)")
+                }
+                vector_columns = {
+                    row["name"]
+                    for row in conn.execute("PRAGMA table_info(agent_context_vectors)")
+                }
+                self.assertIn("content_hash", chunk_columns)
+                self.assertIn("content_hash", vector_columns)
+                self.assertTrue(
+                    conn.execute(
+                        "SELECT 1 FROM sqlite_master "
+                        "WHERE type = 'table' AND name = 'agent_context_dense_vectors'"
+                    ).fetchone()
+                )
+                self.assertTrue(
+                    conn.execute(
+                        "SELECT 1 FROM sqlite_master "
+                        "WHERE type = 'index' AND name = 'idx_agent_context_dense_model'"
+                    ).fetchone()
+                )
+                state = conn.execute(
+                    "SELECT dirty, full_rebuild FROM agent_context_index_state WHERE id = 1"
+                ).fetchone()
+                self.assertEqual((state["dirty"], state["full_rebuild"]), (1, 1))
+                self.assertEqual(
+                    conn.execute("PRAGMA user_version").fetchone()[0],
+                    CURRENT_SCHEMA_VERSION,
+                )
 
     def test_release_audit_rejects_private_agent_data(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
**修复旧用户数据库 schema 缺失 `content_hash` 导致的启动报错：`sqlite3.OperationalError: table agent_context_chunks has no column named content_hash`**
* Added `_ensure_agent_context_schema` in `db.py` to automatically add missing `content_hash` columns to `agent_context_chunks` and `agent_context_vectors`, and to create the `agent_context_dense_vectors` table and related index if missing. Ensures the agent context schema is kept up-to-date during initialization. [[1]](diffhunk://#diff-6d3976ff9332db5f385eeed4ad8635752eab108767877abdd0410f88da990477R642) [[2]](diffhunk://#diff-6d3976ff9332db5f385eeed4ad8635752eab108767877abdd0410f88da990477R698-R751) [[3]](diffhunk://#diff-6d3976ff9332db5f385eeed4ad8635752eab108767877abdd0410f88da990477R863)

**修复后台索引重建线程 `Segmentation fault` 会直接拖死 Web 主进程的问题**
原因：迁移数据库，触发全量索引重建，失败导致 Web 主进程崩溃。

* Refactored `AgentIndexWorker` in `agent_indexer.py` to run the indexing loop in a supervised subprocess using the `multiprocessing` module, improving isolation and fault tolerance. Added logic to handle process exits, including signal-based terminations, and to record failures in the database. [[1]](diffhunk://#diff-12c11c79bd2e0b6a8943b29d69453d40ac5f1d33ce646bd517a159e492123321R2-R6) [[2]](diffhunk://#diff-12c11c79bd2e0b6a8943b29d69453d40ac5f1d33ce646bd517a159e492123321R16-R160)
* Added `_format_process_exit` and `_record_subprocess_exit` methods to log and persist information about abnormal subprocess exits.

**增加测试**

* Added a test in `test_agent_system.py` to verify that the worker records a failed status with the correct error message when the subprocess exits due to a signal.
* Added a test in `test_release_runtime.py` to ensure that missing `content_hash` columns and the `agent_context_dense_vectors` table are added to old databases during initialization, and that schema state is updated accordingly.

Fixes #1